### PR TITLE
修改了admin.conf的server地址为web界面上指定的endpoint。

### DIFF
--- a/kubernetes-playbook/v1.12.2/master.ansible
+++ b/kubernetes-playbook/v1.12.2/master.ansible
@@ -153,6 +153,12 @@
   shell: |
     kubeadm init --config {{ path }}/kubeadm.conf
 
+- name: change admin.conf's endpoint to web's endpoint
+  lineinfile:
+    dest: /etc/kubernetes/admin.conf
+    regexp: "server:"
+    line: "    server: https://{{ endpoint }}"
+	
 - name: fetch admin.conf
   fetch:
     src: '{{ item.src }}'


### PR DESCRIPTION
为了使kubectl命令实际连接web界面上配置的endpoint，修改kubeadm生成的admin.conf文件，使其地址为web界面上配置的endpoint。